### PR TITLE
feat: 공통 Response Model 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,21 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/nextjob/base/exception/CustomException.java
+++ b/src/main/java/com/nextjob/base/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.nextjob.base.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/nextjob/base/exception/ErrorCode.java
+++ b/src/main/java/com/nextjob/base/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.nextjob.base.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    NOT_FOUND_END_POINT(40400, HttpStatus.NOT_FOUND, "찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
+    private final Integer code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/nextjob/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nextjob/base/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.nextjob.base.exception;
+
+import com.nextjob.base.web.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // 존재하지 않는 요청에 대한 예외
+    @ExceptionHandler(value = {NoHandlerFoundException.class, HttpRequestMethodNotSupportedException.class})
+    public ApiResponse<?> handleNoPageFoundException(Exception e) {
+        log.error("GlobalExceptionHandler catch NoHandlerFoundException : {}", e.getMessage());
+        return ApiResponse.fail(new CustomException(ErrorCode.NOT_FOUND_END_POINT));
+    }
+
+
+    // 커스텀 예외
+    @ExceptionHandler(value = {CustomException.class})
+    public ApiResponse<?> handleCustomException(CustomException e) {
+        log.error("handleCustomException() in GlobalExceptionHandler throw CustomException : {}", e.getMessage());
+        return ApiResponse.fail(e);
+    }
+
+    // 기본 예외
+    @ExceptionHandler(value = {Exception.class})
+    public ApiResponse<?> handleException(Exception e) {
+        log.error("handleException() in GlobalExceptionHandler throw Exception : {}", e.getMessage());
+        e.printStackTrace();
+        return ApiResponse.fail(new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/nextjob/base/web/response/ApiResponse.java
+++ b/src/main/java/com/nextjob/base/web/response/ApiResponse.java
@@ -1,0 +1,27 @@
+package com.nextjob.base.web.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.nextjob.base.exception.CustomException;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+
+public record ApiResponse<T>(
+        @JsonIgnore
+        HttpStatus httpStatus,
+        boolean success,
+        @Nullable T data,
+        @Nullable ExceptionDto error
+) {
+
+    public static <T> ApiResponse<T> ok(@Nullable final T data) {
+        return new ApiResponse<>(HttpStatus.OK, true, data, null);
+    }
+
+    public static <T> ApiResponse<T> created(@Nullable final T data) {
+        return new ApiResponse<>(HttpStatus.CREATED, true, data, null);
+    }
+
+    public static <T> ApiResponse<T> fail(final CustomException e) {
+        return new ApiResponse<>(e.getErrorCode().getHttpStatus(), false, null, ExceptionDto.of(e.getErrorCode()));
+    }
+}

--- a/src/main/java/com/nextjob/base/web/response/ExceptionDto.java
+++ b/src/main/java/com/nextjob/base/web/response/ExceptionDto.java
@@ -1,0 +1,23 @@
+package com.nextjob.base.web.response;
+
+import com.nextjob.base.exception.ErrorCode;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ExceptionDto {
+    @NotNull
+    private final Integer code;
+
+    @NotNull
+    private final String message;
+
+    public ExceptionDto(ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+
+    public static ExceptionDto of(ErrorCode errorCode) {
+        return new ExceptionDto(errorCode);
+    }
+}


### PR DESCRIPTION
**작업 사항**
- 공통 Response 형식 추가
   - `ErrorCode.java`: 에러 코드 정의
   - `ApiResponse.java`: Response 형식 정의
   - `ExceptionDto.java`: ErrorCode enum의 코드와 메시지를 포장해서 반환
   - `GlobalExceptionHandler.java`: 예외 유형에 따라 ApiResponse.fail(...) 메서드 호출로 통일된 에러 응답 처리
- 사용 방법
      - 성공: `return ApiResponse.ok(data)`
      - 실패: `throw new CustomException(ErrorCode.XYZ)`
---
**참고**
- https://velog.io/@tkdwns414/Spring-Boot-%EA%B3%B5%ED%86%B5-%EC%9D%91%EB%8B%B5%EC%9A%A9-ApiResponse-%EB%A7%8C%EB%93%A4%EA%B8%B0