### PR TITLE
fix: API 파라미터 매핑 시 userId가 아닌 user_id로 수정

### DIFF
--- a/src/main/java/com/nextjob/back/post/web/PostController.java
+++ b/src/main/java/com/nextjob/back/post/web/PostController.java
@@ -37,7 +37,7 @@ public class PostController {
         param.put("type", type);
         param.put("role", role);
         param.put("search", search);
-        param.put("userId", userId);
+        param.put("user_id", userId);
         param.put("offset", (page - 1) * pageSize);
         param.put("limit", pageSize);
 


### PR DESCRIPTION
**작업 사항**
- CamelCase param에 파라미터 넣을 때 userId가 아닌 user_id로 넣도록 수정
  - CamelCase는 snake_case일 경우에만 CamelCase로 변경해주기 때문에 userId -> userid로 변경됨
