### PR TITLE
add: 사용자 정보 수정 API 내에서 이전 이미지 S3에서 삭제하는 로직 추가

### DIFF
--- a/src/main/java/com/nextjob/back/user/service/UserMapper.java
+++ b/src/main/java/com/nextjob/back/user/service/UserMapper.java
@@ -29,7 +29,8 @@ public interface UserMapper {
             @Param("name") String name,
             @Param("techStack") String techStack,
             @Param("description") String description,
-            @Param("userType") String userType
+            @Param("userType") String userType,
+            @Param("profileImageUrl") String profileImageUrl
     );
 
     /* 사용자 노출 여부 수정 */

--- a/src/main/java/com/nextjob/back/user/service/UserService.java
+++ b/src/main/java/com/nextjob/back/user/service/UserService.java
@@ -17,7 +17,14 @@ public interface UserService {
     boolean suggestToUser(int userId, int projectId);
 
     /* 사용자 정보 수정 */
-    void updateUser(int userId, String name, String techStack, String description, String userType);
+    void updateUser(
+            int userId,
+            String name,
+            String techStack,
+            String description,
+            String userType,
+            String profileImageUrl
+    );
 
     /* 사용자 노출 여부 수정 */
     void updateUserVisibility(int userId, Boolean isVisible);

--- a/src/main/java/com/nextjob/back/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nextjob/back/user/service/impl/UserServiceImpl.java
@@ -63,8 +63,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void updateUser(int userId, String name, String techStack, String description, String userType) {
-        userMapper.updateUser(userId, name, techStack, description, userType);
+    public void updateUser(int userId, String name, String techStack, String description, String userType, String profileImageUrl) {
+        userMapper.updateUser(userId, name, techStack, description, userType, profileImageUrl);
     }
 
     @Override

--- a/src/main/resources/sqlmap/user/UserMapper.xml
+++ b/src/main/resources/sqlmap/user/UserMapper.xml
@@ -98,7 +98,11 @@
 
     <update id="updateUser">
         UPDATE users
-        SET name = #{name}, tech_stack = #{techStack}, description = #{description}, user_type = #{userType}
+        SET name = #{name},
+            tech_stack = #{techStack},
+            description = #{description},
+            user_type = #{userType},
+            profile_image = #{profileImageUrl}
         WHERE user_id = #{userId}
     </update>
 


### PR DESCRIPTION
**작업 사항**
- 변경하려는 사용자 이미지 URL을 body로 받도록 코드 추가
- 사용자 이미지 수정 시, 사용자 정보 수정 API에서 이전 이미지를 S3로부터 삭제하는 로직 추가