### PR TITLE
fix: 이미지 등록 시, 이전 이미지가 있고 변경되었을 경우에만 S3에서 삭제하도록 조건 수정

### DIFF
--- a/src/main/java/com/nextjob/back/user/web/UserController.java
+++ b/src/main/java/com/nextjob/back/user/web/UserController.java
@@ -9,6 +9,7 @@ import com.nextjob.base.exception.ErrorCode;
 import com.nextjob.base.util.CamelCaseMap;
 import com.nextjob.base.web.response.ApiResponse;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -91,13 +92,13 @@ public class UserController {
             throw new CustomException(ErrorCode.NOT_FOUND);
         }
 
-        String pastProfileImageUrl = user.get("profileImage").toString();
+        String pastProfileImageUrl = user.getString("profileImage");
 
         userService.updateUser(userId, name, techStack, description, userType, profileImageUrl);
         user = userService.findUserDetail(userId);
 
         // 이미지 변경되었으면 이전 이미지 S3에서 삭제처리
-        if (!Objects.equals(user.getString("profileImage"), pastProfileImageUrl)) {
+        if (StringUtils.hasText(pastProfileImageUrl) && !Objects.equals(user.getString("profileImage"), pastProfileImageUrl)) {
             imageService.deleteImage(pastProfileImageUrl);
         }
 


### PR DESCRIPTION
**작업 사항**
- 새로 가입한 유저가 마이페이지에서 프로필이미지를 수정할 경우 오류 발생
  - 정보 수정 API에서 이미지 등록 시, 이전 이미지와 url이 다를 경우 이전 이미지를 S3에서 삭제해주고 있음
  - 새로 가입한 유저의 경우에는 이전 이미지가 없기 때문에 오류 발생
  - 이전 이미지가 있고, 변경된 url과 다를 경우에만 S3에서 삭제하도록 수정